### PR TITLE
Add validation to fix error of "'<' not supported between 'str' and 'int'

### DIFF
--- a/virtualbmc/config.py
+++ b/virtualbmc/config.py
@@ -75,6 +75,15 @@ class VirtualBMCConfig(object):
         self._conf_dict['default']['show_passwords'] = utils.str2bool(
             self._conf_dict['default']['show_passwords'])
 
+        self._conf_dict['default']['server_port'] = int(
+            self._conf_dict['default']['server_port'])
+
+        self._conf_dict['default']['server_spawn_wait'] = int(
+            self._conf_dict['default']['server_spawn_wait'])
+
+        self._conf_dict['default']['server_response_timeout'] = int(
+            self._conf_dict['default']['server_response_timeout'])
+
         self._conf_dict['ipmi']['session_timeout'] = int(
             self._conf_dict['ipmi']['session_timeout'])
 


### PR DESCRIPTION
…f 'str' and 'int'" when defining server_response_timeout value in virtualbmc.conf. The error is trigger because the config parameters from the configuration file are read as strings and everything else assume that value is an integer (as the default of 5000).

The patch also include validations for server_spawn_wait and server_port to check the values are valid integers.